### PR TITLE
Force pybuild to not create __pycache__ files at build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,6 @@
 #!/usr/bin/make -f
 
+export PYTHONDONTWRITEBYTECODE=1
+
 %:
 	dh $@ --with python3 --buildsystem=pybuild


### PR DESCRIPTION
Minimal change to make turnkey-conffile reproducible.